### PR TITLE
fix format & update junit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,11 @@
       <artifactId>script-security</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.20</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/amadeus/jenkins/opentracing/config/impl/NullConfig.java
+++ b/src/main/java/com/amadeus/jenkins/opentracing/config/impl/NullConfig.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 


### PR DESCRIPTION
## 1. fix formatting error

When I tried to build the project, the following error would occur.
```
[ERROR] Found 1 non-complying files, failing build
[ERROR] To fix formatting errors, run "mvn com.coveo:fmt-maven-plugin:format"
```
After running `mvn com.coveo:fmt-maven-plugin:format`, the import `org.kohsuke.accmod.restrictions.DoNotUse` has been removed because it is never used
https://github.com/AmadeusITGroup/jenkins-opentracing-plugin/blob/56cc6cd903770d35db27d3cacd86ded1e4b6f43a/src/main/java/com/amadeus/jenkins/opentracing/config/impl/NullConfig.java#L13

### Reproduce step
* Test Environment
  > Apache Maven: 3.6.3
  > Java: 11.0.21
  > OS: Ubuntu 20.04.6 LTS
  > Linux kernel: 5.4.0-167-generic

```Shell
mvn install -am -DskipTests
```

## 2. update jenkins plugins junit version
When running `InjectedTest` test, the following error would occur.
```
[ERROR] Tests run: 8, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 11.488 s <<< FAILURE! - in InjectedTest
[ERROR] org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive  Time elapsed: 0.011 s  <<< ERROR!
java.lang.Error: Plugin matrix-project failed to start
Caused by: java.io.IOException: Matrix Project Plugin version 1.14 failed to load.
 - JUnit Plugin version 1.3 is older than required. To fix, install version 1.20 or later.
```
To make the test pass, I updated junit version in [pom.xml](https://github.com/NDR0216/jenkins-opentracing-plugin/blob/aa46911fa21dc83c402630569c0206868e7daae2/pom.xml#L165-L169)

### Reproduce step
* Test Environment
  > Apache Maven: 3.6.3
  > Java: 11.0.21
  > OS: Ubuntu 20.04.6 LTS
  > Linux kernel: 5.4.0-167-generic

```Shell
mvn test -Dtest=InjectedTest
```