### PR TITLE
update junit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,11 @@
       <artifactId>script-security</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.20</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## update jenkins plugins junit version
When running `InjectedTest` test, the following error would occur.
```
[ERROR] Tests run: 8, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 11.488 s <<< FAILURE! - in InjectedTest
[ERROR] org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive  Time elapsed: 0.011 s  <<< ERROR!
java.lang.Error: Plugin matrix-project failed to start
Caused by: java.io.IOException: Matrix Project Plugin version 1.14 failed to load.
 - JUnit Plugin version 1.3 is older than required. To fix, install version 1.20 or later.
```
To make the test pass, I updated junit version in [pom.xml](https://github.com/NDR0216/jenkins-opentracing-plugin/blob/aa46911fa21dc83c402630569c0206868e7daae2/pom.xml#L165-L169)

### Reproduce step
* Test Environment
  > Apache Maven: 3.6.3
  > Java: 11.0.21
  > OS: Ubuntu 20.04.6 LTS
  > Linux kernel: 5.4.0-167-generic

```Shell
mvn test -Dtest=InjectedTest
```